### PR TITLE
Add possibility to log from Beanstalk to Cloudwatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ module "development" {
   eb_ec2_key_name        = "TestTerraform"  # Mandatory. Must exist in the account
   eb_environment_type    = "SingleInstance" # Optional
   eb_instance_type       = "t3.small"       # Optional
+  eb_stream_logs         = "false"          # Optional
   eb_solution_stack_name = "${data.aws_elastic_beanstalk_solution_stack.docker_latest.name}" # Optional
 }
 ```
@@ -99,7 +100,7 @@ module "development" {
   rds_username        = "joseperezuser"     # Mandatory
   rds_password        = "unPassword!1234"   # Mandatory
   rds_engine          = "postgres"          # Optional
-  rds_engine_version  = "11.4"             # Optional
+  rds_engine_version  = "11.4"              # Optional
   rds_port            = "5432"              # Optional
   rds_multi_az        = false               # Optional
   rds_instance_type   = "db.t2.micro"       # Optional
@@ -109,6 +110,7 @@ module "development" {
   eb_ec2_key_name        = "TestTerraform"  # Mandatory. Must exist in the account
   eb_environment_type    = "SingleInstance" # Optional
   eb_instance_type       = "t3.small"       # Optional
+  eb_stream_logs         = "false"          # Optional
   eb_solution_stack_name = "${data.aws_elastic_beanstalk_solution_stack.docker_latest.name}" # Optional
 }
 
@@ -130,10 +132,11 @@ module "production" {
   rds_instance_type   = "db.t2.micro"       # Optional
 
   eb_application         = "test-app"       # Mandatory
-  eb_environment         = "production"    # Mandatory
+  eb_environment         = "production"     # Mandatory
   eb_ec2_key_name        = "TestTerraform"  # Mandatory. Must exist in the account
-  eb_environment_type    = "LoadBalanced" # Optional
+  eb_environment_type    = "LoadBalanced"   # Optional
   eb_instance_type       = "t3.small"       # Optional
+  eb_stream_logs         = "true"           # Optional
   eb_solution_stack_name = "${data.aws_elastic_beanstalk_solution_stack.docker_latest.name}" # Optional
 }
 ```

--- a/aws/eb_rds/main.tf
+++ b/aws/eb_rds/main.tf
@@ -24,6 +24,7 @@ module "server" {
   environment_type    = "${var.eb_environment_type}"
   # load_balancer_type  = "${var.eb_load_balancer_type}"
   instance_type       = "${var.eb_instance_type}"
+  stream_logs         = "${var.eb_stream_logs}"
 }
 
 # Create the database

--- a/aws/eb_rds/readme.md
+++ b/aws/eb_rds/readme.md
@@ -28,7 +28,7 @@ module "env" {
   rds_username        = "joseperezuser"     # Mandatory
   rds_password        = "unPassword!1234"   # Mandatory
   rds_engine          = "postgres"          # Optional
-  rds_engine_version  = "11.4"             # Optional
+  rds_engine_version  = "11.4"              # Optional
   rds_port            = "5432"              # Optional
   rds_multi_az        = false               # Optional
   rds_instance_type   = "db.t2.micro"       # Optional
@@ -39,6 +39,7 @@ module "env" {
   eb_environment_type    = "SingleInstance" # Optional
   eb_instance_type       = "t2.small"       # Optional
   eb_solution_stack_name = "64bit Amazon Linux 2018.03 v2.10.0 running Docker 17.12.1-ce" # Optional
+  eb_stream_logs         = "true"           # Optional
 }
 ```
 

--- a/aws/eb_rds/variables.tf
+++ b/aws/eb_rds/variables.tf
@@ -70,5 +70,9 @@ variable "eb_environment_type" {
 }
 
 variable "eb_instance_type" {
-  default = "t2.small"
+  default = "t3.small"
+}
+
+variable "eb_stream_logs" {
+  default = "false"
 }

--- a/aws/elasticache/readme.md
+++ b/aws/elasticache/readme.md
@@ -35,6 +35,7 @@ module "env" {
   eb_ec2_key_name        = "somecustomkey"  # Mandatory. Must exist in the account
   eb_environment_type    = "SingleInstance" # Optional
   eb_instance_type       = "t2.micro"       # Optional
+  eb_stream_logs         = "true"           # Optional
   eb_solution_stack_name = "64bit Amazon Linux 2018.03 v2.12.17 running Docker 18.06.1-ce" # Optional
 }
 

--- a/aws/elasticbeanstalk/environment/main.tf
+++ b/aws/elasticbeanstalk/environment/main.tf
@@ -18,8 +18,13 @@ variable "environment_type" {
 }
 
 variable "instance_type" {
-  default = "t2.small"
+  default = "t3.small"
 }
+
+variable "stream_logs" {
+  default = "false"
+}
+
 
 # variable "load_balancer_type" {
 #   default = "classic"
@@ -100,6 +105,24 @@ resource "aws_elastic_beanstalk_environment" "env" {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "DATABASE_URL"
     value     = "${var.rds_connection_url}"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+    name      = "StreamLogs"
+    value     = "${var.stream_logs}"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+    name      = "DeleteOnTerminate"
+    value     = "false"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+    name      = "RetentionInDays"
+    value     = "30"
   }
 }
 


### PR DESCRIPTION
# Summary

- Allow logging via Cloudwatch of the Elastic Beanstalk instances, defaulting to false (not logging).
- Default to t3.small, they are cheaper than the t2.small.