### PR TITLE
[AWS] Output ec2 role and fixes

### DIFF
--- a/aws/eb_rds/output.tf
+++ b/aws/eb_rds/output.tf
@@ -17,3 +17,7 @@ output "vpc_id" {
 output "servers_sg_id" {
   value = "${module.vpc.servers_sg_id}"
 }
+
+output "eb_instance_profile" {
+  value = "${module.server.eb-ec2-role}"
+}

--- a/aws/elasticbeanstalk/environment/main.tf
+++ b/aws/elasticbeanstalk/environment/main.tf
@@ -98,7 +98,7 @@ resource "aws_elastic_beanstalk_environment" "env" {
   setting {
     namespace = "aws:autoscaling:asg"
     name      = "MaxSize"
-    value     = "2"
+    value     = "${var.environment_type == "SingleInstance" ? "1" : "2"}"
   }
 
   setting {

--- a/aws/elasticbeanstalk/environment/role.tf
+++ b/aws/elasticbeanstalk/environment/role.tf
@@ -90,5 +90,5 @@ resource "aws_iam_role_policy_attachment" "eb_health" {
 }
 
 output "eb-ec2-role" {
-  value = "${aws_iam_role.ec2-role}"
+  value = "${aws_iam_role.ec2-role.name}"
 }

--- a/aws/elasticbeanstalk/environment/role.tf
+++ b/aws/elasticbeanstalk/environment/role.tf
@@ -88,3 +88,7 @@ resource "aws_iam_role_policy_attachment" "eb_health" {
   role       = "${aws_iam_role.eb-service-role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkEnhancedHealth"
 }
+
+output "eb-ec2-role" {
+  value = "${aws_iam_role.ec2-role}"
+}

--- a/aws/elasticbeanstalk/environment/role.tf
+++ b/aws/elasticbeanstalk/environment/role.tf
@@ -45,7 +45,7 @@ resource "aws_iam_role_policy_attachment" "describe_environment" {
 }
 
 resource "aws_iam_policy" "describe_environment" {
-  name        = "DescribeEnvironment${join('', split('-', title(var.application)))}${title(var.environment)}"
+  name        = "describe-environmen-${var.application}-${var.environment}"
   description = "Allows EC2 instance to describe the Elastic Beanstalk environment"
 
   policy = <<EOF

--- a/aws/elasticbeanstalk/environment/role.tf
+++ b/aws/elasticbeanstalk/environment/role.tf
@@ -45,7 +45,7 @@ resource "aws_iam_role_policy_attachment" "describe_environment" {
 }
 
 resource "aws_iam_policy" "describe_environment" {
-  name        = "describe-environmen-${var.application}-${var.environment}"
+  name        = "describe-environment-${var.application}-${var.environment}"
   description = "Allows EC2 instance to describe the Elastic Beanstalk environment"
 
   policy = <<EOF


### PR DESCRIPTION
## Summary

- Output EB Instance profile, in order to attach extra policies in terraform
- Fix DescribeEnvironmnet policy syntax error in name
- Fix alwas diff when the environment is single instance